### PR TITLE
Refactor API endpoints for emergency report and receipt voiding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@a-cube-io/ereceipts-js-sdk",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@a-cube-io/ereceipts-js-sdk",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@a-cube-io/ereceipts-js-sdk",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@a-cube-io/ereceipts-js-sdk",
-      "version": "2.3.1",
+      "version": "2.3.2",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a-cube-io/ereceipts-js-sdk",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "ACube E-Receipt SDK for multi-platform support",
   "type": "module",
   "main": "./dist/index.cjs.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a-cube-io/ereceipts-js-sdk",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "ACube E-Receipt SDK for multi-platform support",
   "type": "module",
   "main": "./dist/index.cjs.js",

--- a/src/infrastructure/driven/api/mf2-emergency-report.repository.impl.ts
+++ b/src/infrastructure/driven/api/mf2-emergency-report.repository.impl.ts
@@ -17,7 +17,7 @@ export class Mf2EmergencyReportRepositoryImpl implements IMf2EmergencyReportRepo
   async upload(serialNumber: string, input: EmergencyReportInput): Promise<EmergencyReportOutput> {
     const apiInput = EmergencyReportMapper.toCreateApiInput(input);
     const response = await this.http.post<EmergencyReportApiOutput>(
-      `/mf2/pems/${serialNumber}/upload-emergency-report`,
+      `/mf2/pems/${serialNumber}/upload-emergency-reports`,
       apiInput
     );
     return EmergencyReportMapper.fromApiOutput(response.data);

--- a/src/infrastructure/driven/api/mf2-emergency-report.repository.impl.ts
+++ b/src/infrastructure/driven/api/mf2-emergency-report.repository.impl.ts
@@ -17,7 +17,7 @@ export class Mf2EmergencyReportRepositoryImpl implements IMf2EmergencyReportRepo
   async upload(serialNumber: string, input: EmergencyReportInput): Promise<EmergencyReportOutput> {
     const apiInput = EmergencyReportMapper.toCreateApiInput(input);
     const response = await this.http.post<EmergencyReportApiOutput>(
-      `/mf2/pems/${serialNumber}/upload-emergency-reports`,
+      `/mf2/pems/${serialNumber}/emergency-reports`,
       apiInput
     );
     return EmergencyReportMapper.fromApiOutput(response.data);

--- a/src/infrastructure/driven/api/point-of-sale.repository.impl.ts
+++ b/src/infrastructure/driven/api/point-of-sale.repository.impl.ts
@@ -55,7 +55,7 @@ export class PointOfSaleRepositoryImpl implements IPointOfSaleRepository {
 
   async uploadEmergencyReport(serialNumber: string, input: EmergencyReportInput): Promise<void> {
     const apiInput = PointOfSaleMapper.toEmergencyReportApiInput(input);
-    await this.http.post(`/mf1/pems/${serialNumber}/emergency-report`, apiInput);
+    await this.http.post(`/mf1/pems/${serialNumber}/emergency-reports`, apiInput);
   }
 
   async communicateOffline(serialNumber: string, input: PEMStatusOfflineRequest): Promise<void> {

--- a/src/infrastructure/driven/api/receipt.repository.impl.ts
+++ b/src/infrastructure/driven/api/receipt.repository.impl.ts
@@ -70,17 +70,17 @@ export class ReceiptRepositoryImpl implements IReceiptRepository {
 
   async voidReceipt(input: VoidReceiptInput): Promise<void> {
     const apiInput = ReceiptMapper.voidInputToApi(input);
-    await this.http.delete('/mf1/receipts', { data: apiInput });
+    await this.http.post('/mf1/receipts/void', { data: apiInput });
   }
 
   async voidViaDifferentDevice(input: VoidViaDifferentDeviceInput): Promise<void> {
     const apiInput = ReceiptMapper.voidViaDifferentDeviceToApi(input);
-    await this.http.delete('/mf1/receipts/void-via-different-device', { data: apiInput });
+    await this.http.post('/mf1/receipts/void-via-different-device', { data: apiInput });
   }
 
   async voidWithProof(input: VoidWithProofInput): Promise<void> {
     const apiInput = ReceiptMapper.voidWithProofToApi(input);
-    await this.http.delete('/mf1/receipts/void-with-proof', { data: apiInput });
+    await this.http.post('/mf1/receipts/void-with-proof', { data: apiInput });
   }
 
   async returnItems(input: ReceiptReturnInput): Promise<Receipt> {

--- a/src/infrastructure/driven/api/receipt.repository.impl.ts
+++ b/src/infrastructure/driven/api/receipt.repository.impl.ts
@@ -70,17 +70,17 @@ export class ReceiptRepositoryImpl implements IReceiptRepository {
 
   async voidReceipt(input: VoidReceiptInput): Promise<void> {
     const apiInput = ReceiptMapper.voidInputToApi(input);
-    await this.http.post('/mf1/receipts/void', { data: apiInput });
+    await this.http.post('/mf1/receipts/void', apiInput);
   }
 
   async voidViaDifferentDevice(input: VoidViaDifferentDeviceInput): Promise<void> {
     const apiInput = ReceiptMapper.voidViaDifferentDeviceToApi(input);
-    await this.http.post('/mf1/receipts/void-via-different-device', { data: apiInput });
+    await this.http.post('/mf1/receipts/void-via-different-device', apiInput);
   }
 
   async voidWithProof(input: VoidWithProofInput): Promise<void> {
     const apiInput = ReceiptMapper.voidWithProofToApi(input);
-    await this.http.post('/mf1/receipts/void-with-proof', { data: apiInput });
+    await this.http.post('/mf1/receipts/void-with-proof', apiInput);
   }
 
   async returnItems(input: ReceiptReturnInput): Promise<Receipt> {


### PR DESCRIPTION
- Updated endpoint paths in Mf2EmergencyReportRepositoryImpl and PointOfSaleRepositoryImpl to use plural forms for consistency.
- Changed HTTP method from DELETE to POST for voiding receipts in ReceiptRepositoryImpl to align with API standards.